### PR TITLE
Tolerate Rector 2.x releases without FirstClassCallableRector

### DIFF
--- a/config.php
+++ b/config.php
@@ -11,7 +11,9 @@ function config(RectorConfig $rectorConfig): void
     /** @var class-string<\Rector\Contract\Rector\RectorInterface> $firstClassCallableRector */
     $firstClassCallableRector = class_exists(\Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector::class)
         ? \Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector::class
-        : \Rector\Php81\Rector\Array_\FirstClassCallableRector::class;
+        // Referenced as a string because recent Rector 2.x releases removed the class,
+        // which makes static analysis fail to resolve it.
+        : 'Rector\Php81\Rector\Array_\FirstClassCallableRector';
     $rectorConfig->rule($firstClassCallableRector);
 
     $rectorConfig->rule(\MLL\RectorConfig\Rector\ElvisToCoalesceRector::class);

--- a/config.php
+++ b/config.php
@@ -4,7 +4,9 @@ namespace MLL\RectorConfig;
 
 use Rector\Config\RectorConfig;
 
-/** Configure rector with PHP rules. */
+/**
+ * Configure rector with PHP rules.
+ */
 function config(RectorConfig $rectorConfig): void
 {
     // Use ArrayToFirstClassCallableRector in Rector 2.x, FirstClassCallableRector in 1.x
@@ -20,7 +22,9 @@ function config(RectorConfig $rectorConfig): void
     $rectorConfig->rule(\MLL\RectorConfig\Rector\IfThrowToCoalesceThrowRector::class);
 }
 
-/** Configure rector with Laravel rules. */
+/**
+ * Configure rector with Laravel rules.
+ */
 function laravel(RectorConfig $rectorConfig): void
 {
     config($rectorConfig);


### PR DESCRIPTION
`static-code-analysis` fails on `--prefer-highest` installs: recent Rector 2.x releases removed `Rector\Php81\Rector\Array_\FirstClassCallableRector`, and the composer constraint still allows Rector 1.x, so the fallback branch of the `class_exists` ternary references a class phpstan cannot resolve.

Referencing the legacy class as a string keeps the 1.x fallback working at runtime while giving static analysis nothing to resolve. Dropping 1.x support would be the alternative, but that is a wider decision than this failure warrants.

Non-functional only — no behavior change on either Rector major.